### PR TITLE
docs: typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ class MyElement extends HTMLElement {
   }
 
   connectedCallback() {
-    this.shadowroot.innerHTML = '<h1>Hello World</h1>';
+    this.shadowRoot.innerHTML = '<h1>Hello World</h1>';
   }
 }
 


### PR DESCRIPTION
If you copy/paste the `src/components/my-element.js` snippet you get a `TypeError: Cannot set properties of undefined (setting 'innerHTML')` error.